### PR TITLE
[12.0][FIX] helpdesk_mgmt_timesheet_ticket_name: write permissions on timesheets not bypassed on computed field

### DIFF
--- a/helpdesk_mgmt_timesheet_ticket_name/__manifest__.py
+++ b/helpdesk_mgmt_timesheet_ticket_name/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": """
         Adds title to ticket number identifying a ticket in timesheet view.
     """,
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "license": "LGPL-3",
     "category": "helpdesk",
     "author": "Solvos",

--- a/helpdesk_mgmt_timesheet_ticket_name/models/account_analytic_line.py
+++ b/helpdesk_mgmt_timesheet_ticket_name/models/account_analytic_line.py
@@ -11,6 +11,7 @@ class AccountAnalyticLine(models.Model):
         related='ticket_id.complete_name',
         store=True,
         index=True,
+        compute_sudo=True,
     )
     ticket_name = fields.Char(
         related='ticket_id.name'


### PR DESCRIPTION
Fix permission bug when a user tried to adds timesheet to a ticket that was not assigned