### PR TITLE
[15.0][IMP] helpdesk_mgmt_team_customer: allowed partners for tickets

### DIFF
--- a/helpdesk_mgmt_team_customer/__manifest__.py
+++ b/helpdesk_mgmt_team_customer/__manifest__.py
@@ -8,11 +8,11 @@
     "website": "https://github.com/solvosci/slv-helpdesk",
     "license": "AGPL-3",
     "category": "After-Sales",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "depends": [
         "helpdesk_mgmt"
     ],
     "data": [
-        "views/helpdesk_ticket_team_form.xml"
+        "views/helpdesk_ticket_team_views.xml",
     ]
 }

--- a/helpdesk_mgmt_team_customer/__manifest__.py
+++ b/helpdesk_mgmt_team_customer/__manifest__.py
@@ -8,7 +8,7 @@
     "website": "https://github.com/solvosci/slv-helpdesk",
     "license": "AGPL-3",
     "category": "After-Sales",
-    "version": "15.0.1.1.0",
+    "version": "15.0.1.2.0",
     "depends": [
         "helpdesk_mgmt"
     ],

--- a/helpdesk_mgmt_team_customer/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_team_customer/models/helpdesk_ticket.py
@@ -9,3 +9,10 @@ class HelpdeskTicket(models.Model):
     def _onchange_team_id(self):
         if self.team_id.default_partner_id:
             self.partner_id = self.team_id.default_partner_id
+        res = {}
+        if self.team_id.allowed_partner_ids:
+            res_domain = res.setdefault("domain", {})
+            res_domain.update({"partner_id": [("id", "in", (self.team_id.allowed_partner_ids | self.team_id.default_partner_id).ids)]})
+        else:
+            res["domain"] = {"partner_id": []}
+        return res

--- a/helpdesk_mgmt_team_customer/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_team_customer/models/helpdesk_ticket.py
@@ -10,7 +10,10 @@ class HelpdeskTicket(models.Model):
         if self.team_id.default_partner_id:
             self.partner_id = self.team_id.default_partner_id
         res = {}
-        if self.team_id.allowed_partner_ids:
+        if self.team_id.is_unique_partner:
+            res_domain = res.setdefault("domain", {})
+            res_domain.update({"partner_id": [("id", "=", self.team_id.default_partner_id.id)]})
+        elif self.team_id.allowed_partner_ids:
             res_domain = res.setdefault("domain", {})
             res_domain.update({"partner_id": [("id", "in", (self.team_id.allowed_partner_ids | self.team_id.default_partner_id).ids)]})
         else:

--- a/helpdesk_mgmt_team_customer/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_team_customer/models/helpdesk_ticket_team.py
@@ -7,5 +7,10 @@ class HelpdeskTicketTeam(models.Model):
 
     default_partner_id=fields.Many2one(
         comodel_name="res.partner",
-        string="Default partner"
+        domain="[('is_company', '=' , True)]"
+    )
+
+    allowed_partner_ids=fields.Many2many(
+        comodel_name="res.partner",
+        domain="[('is_company', '=', True)]",
     )

--- a/helpdesk_mgmt_team_customer/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_team_customer/models/helpdesk_ticket_team.py
@@ -1,16 +1,21 @@
 #    Copyright (C) 2024 Solvos Consultoría Informática <www.solvos.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import models, fields
+from odoo import api, models, fields
 
 class HelpdeskTicketTeam(models.Model):
     _inherit="helpdesk.ticket.team"
 
     default_partner_id=fields.Many2one(
         comodel_name="res.partner",
-        domain="[('is_company', '=' , True)]"
     )
+
+    is_unique_partner=fields.Boolean()
 
     allowed_partner_ids=fields.Many2many(
         comodel_name="res.partner",
-        domain="[('is_company', '=', True)]",
     )
+
+    @api.onchange('default_partner_id')
+    def _onchange_default_partner_id(self):
+        if not self.default_partner_id:
+            self.is_unique_partner = False

--- a/helpdesk_mgmt_team_customer/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt_team_customer/views/helpdesk_ticket_team_views.xml
@@ -7,7 +7,8 @@
         <field name="inherit_id" ref="helpdesk_mgmt.view_helpdesk_team_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='show_in_portal']" position="after">
-                <field name="default_partner_id" />                
+                <field name="default_partner_id" />
+                <field name="allowed_partner_ids" />
             </xpath>
         </field>
     </record>

--- a/helpdesk_mgmt_team_customer/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt_team_customer/views/helpdesk_ticket_team_views.xml
@@ -8,7 +8,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='show_in_portal']" position="after">
                 <field name="default_partner_id" />
-                <field name="allowed_partner_ids" />
+                <field name="is_unique_partner" attrs="{'readonly': [('default_partner_id', '=', False)]}" force_save="1" />
+                <field name="allowed_partner_ids" attrs="{'readonly': [('is_unique_partner', '=', True)]}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
With this improvement its possible to set, by helpdesk team, some partners that are the only allowed for a new ticket.